### PR TITLE
Updated build scripts to work in clean subdirectory build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 _publish.R
 _book
 _bookdown_files
+build
 rsconnect
 public
 bookdown-demo.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ deploy:
     skip-cleanup: true
     github-token: $GITHUB_PAT
     keep-history: true
-    local-dir: public
+    local-dir: build/public
     on:
       branch: master
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,16 @@ https://cran.r-project.org/web/packages/miniCRAN/vignettes/miniCRAN-dependency-g
 https://cran.r-project.org/web/packages/pkgnet/vignettes/pkgnet-intro.html
 pkgnet can analyze any R package locally installed. (Run installed.packages() to see the full list of packages installed on your system.)
 
+## Building the book
+
+The `travisScript.sh` uses the Docker image and builds the book in the `build` directory.
+
+Simply run 
+
+```
+./travisScript.sh
+```
+
+to build the book. 
+Output will be saved in the `build/public` directory.
+

--- a/travisScript.sh
+++ b/travisScript.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -x 
 
-chmod -R 777 $PWD
-docker run -v $PWD/:/tmp/metaRbolomics-book -e RENDER_BOOK_TARGET sneumann/metarbolomics-book-base /tmp/metaRbolomics-book/buildbook.sh
+mkdir build/
+cp -R . build/
+chmod -R 777 build/
+docker run -v $PWD/build/:/tmp/metaRbolomics-book -e RENDER_BOOK_TARGET sneumann/metarbolomics-book-base /tmp/metaRbolomics-book/buildbook.sh


### PR DESCRIPTION
This moves the build for travis to a newly, ad-hoc created 'build' directory. This avoids that local files are changed / modified when the book is built locally.